### PR TITLE
Fix an issue where the rakefile the railtie points to is invalid

### DIFF
--- a/lib/wurfl_device/railtie.rb
+++ b/lib/wurfl_device/railtie.rb
@@ -3,7 +3,7 @@
 module WurflDevice
   class Railtie < ::Rails::Railtie
     rake_tasks do
-      load File.join(File.expand_path('../..', File.dirname(__FILE__)), 'lib', 'tasks', 'wurfl.rake')
+      load File.join(File.expand_path('../..', File.dirname(__FILE__)), 'rakelib', 'wurfl_device.rake')
     end
   end
 end


### PR DESCRIPTION
This makes rake tasks fail.

Pointed it to rakelib/wurfl_device.rake
